### PR TITLE
fix: マルチプレイだと特定のプレイヤー以外難易度を変更できないのを修正

### DIFF
--- a/data/world_manager/function/event/difficulty/.mcfunction
+++ b/data/world_manager/function/event/difficulty/.mcfunction
@@ -5,16 +5,16 @@
 # @within function world_manager:event/tick
 
 # -1は閉じたとき。特に難易度を変えず、ゲームルールとかが元に戻る
-    execute if score @p Trigger.Difficulty matches -1 run function world_manager:event/difficulty/close
+    execute if score @s Trigger.Difficulty matches -1 run function world_manager:event/difficulty/close
 # 難易度が1~4に設定された場合、ベッドの時間スキップを有効化する
-    execute if score @p Trigger.Difficulty matches 1..4 run function world_manager:event/difficulty/enable_time_skip/
+    execute if score @s Trigger.Difficulty matches 1..4 run function world_manager:event/difficulty/enable_time_skip/
 # 1
-    execute if score @p Trigger.Difficulty matches 1 run function world_manager:event/difficulty/1
+    execute if score @s Trigger.Difficulty matches 1 run function world_manager:event/difficulty/1
 # 2
-    execute if score @p Trigger.Difficulty matches 2 run function world_manager:event/difficulty/2
+    execute if score @s Trigger.Difficulty matches 2 run function world_manager:event/difficulty/2
 # 3
-    execute if score @p Trigger.Difficulty matches 3 run function world_manager:event/difficulty/3
+    execute if score @s Trigger.Difficulty matches 3 run function world_manager:event/difficulty/3
 # 4
-    execute if score @p Trigger.Difficulty matches 4 run function world_manager:event/difficulty/4
+    execute if score @s Trigger.Difficulty matches 4 run function world_manager:event/difficulty/4
 # 5
-    execute if score @p Trigger.Difficulty matches 5 run function world_manager:event/difficulty/5
+    execute if score @s Trigger.Difficulty matches 5 run function world_manager:event/difficulty/5

--- a/data/world_manager/function/event/difficulty/close.mcfunction
+++ b/data/world_manager/function/event/difficulty/close.mcfunction
@@ -10,4 +10,4 @@
 
 # スコアボードリセット
     scoreboard players reset $sendCommandFeedback Global
-    scoreboard players reset @p Trigger.Difficulty
+    scoreboard players reset @s Trigger.Difficulty

--- a/data/world_manager/function/event/tick.mcfunction
+++ b/data/world_manager/function/event/tick.mcfunction
@@ -5,4 +5,4 @@
 # @within function core:tick/
 
 # 難易度周り
-    function world_manager:event/difficulty/
+    execute as @a[scores={Trigger.Difficulty=-1..5}] run function world_manager:event/difficulty/


### PR DESCRIPTION
<s>マルチプレイだと難易度がうまく設定できなかったバグを修正します。</s>
マルチプレイだと最も`0, 0, 0`に近いプレイヤー以外難易度を変更できないのを修正します。
（再現のためGayserなどを入れていますが、別の通常サーバーでも再現しました）

https://github.com/user-attachments/assets/088eae97-5a25-4262-91fe-3b5f288c6c37


